### PR TITLE
Update battery.sh Return battery % and idle process %

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -1,4 +1,16 @@
 pmset -g batt |
 grep -Eo "\d+%" |
 cut -d% -f1 |
-tr -d "\n" ; top -u -l 1 | head -4
+tr -d "\n" |
+sed 's/^/{"hearts": /' |
+awk '{print $1 $2 ","}'  |
+tr -d "\n" ;
+top |
+head -4 |
+tail -1 |
+grep -Eo "\d+\.+\d+%" |
+tail -1 |
+cut -d% -f1 |
+tr -d "\n" |
+sed 's/^/"magic": /'  |
+awk '{print $1 $2 "}"}'

--- a/index.jsx
+++ b/index.jsx
@@ -224,12 +224,12 @@ export const updateState = (event, previousState) => {
     return previousState
   }
 
+  const outputObj = JSON.parse(event.output)
   const flatHearts = initialState.hearts.flat()
-  const percentage = parseInt(event.output)
-  const numHearts = (percentage / 100) * MAX_HEARTS
+  const numHearts = (outputObj.hearts / 100) * MAX_HEARTS
   const fullHearts = Math.floor(numHearts)
   const remainder = numHearts - fullHearts
-  const magic = event.output.match(/\d+\.\d+%\sidle/)[0].replace('%', '').replace('idle', '')/100
+  const magic = outputObj.magic / 100
 
   if (remainder > 0) {
     let lastHeart = { index: -1, diff: 99 }


### PR DESCRIPTION
Update battery.sh Remove the crazy regex for idle process and get the idle % in batter.sh now. It now returns text containing battery % and idle process %.
'{"hearts":58,"magic":87.52}'
This is returned in event.output as a string which is then converted to JSON object.
{hearts: 58, magic: 87.52}
Then outputObj.hearts and outputObj.magic are used for the numerical values.